### PR TITLE
Use cURL when `allow_url_fopen = Off`

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -200,6 +200,23 @@ class FastImageSize
 		if (empty($this->data))
 		{
 			$this->data = @file_get_contents($filename, null, null, $offset, $length);
+
+			if ($this->data === false) {
+
+				$headers = array(
+			    	'Range: bytes=0-' . ($length - 1)
+			    );
+
+			    $curl = curl_init($filename);
+			    curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+			    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+			    $this->data = curl_exec($curl);
+			    curl_close($curl);
+			    
+			    if (isset($offset)) {
+					$this->data = substr($this->data, $offset);
+				}
+			}
 		}
 
 		// Force length to expected one. Return false if data length

--- a/lib/Type/TypeJpeg.php
+++ b/lib/Type/TypeJpeg.php
@@ -15,7 +15,7 @@ class TypeJpeg extends TypeBase
 {
 	/** @var int JPEG max header size. Headers can be bigger, but we'll abort
 	 *			going throught he header after this */
-	const JPEG_MAX_HEADER_SIZE = 24576*5;
+	const JPEG_MAX_HEADER_SIZE = 122880;
 
 	/** @var string JPEG header */
 	const JPEG_HEADER = "\xFF\xD8";

--- a/lib/Type/TypeJpeg.php
+++ b/lib/Type/TypeJpeg.php
@@ -15,7 +15,7 @@ class TypeJpeg extends TypeBase
 {
 	/** @var int JPEG max header size. Headers can be bigger, but we'll abort
 	 *			going throught he header after this */
-	const JPEG_MAX_HEADER_SIZE = 24576;
+	const JPEG_MAX_HEADER_SIZE = 24576*5;
 
 	/** @var string JPEG header */
 	const JPEG_HEADER = "\xFF\xD8";


### PR DESCRIPTION
Some servers have `allow_url_fopen = Off` and thus file_get_contents wont work, so the alternative is to use cURL.

I also increased the JPEG header size