### PR TITLE
Add support for uppercase filename extensions

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -149,6 +149,7 @@ class FastImageSize
 	 */
 	protected function getImageSizeByExtension($file, $extension)
 	{
+		$extension = strtolower($extension);
 		if (isset($this->classMap[$extension]))
 		{
 			$this->classMap[$extension]->getSize($file);


### PR DESCRIPTION
### Issue
As of commit 02abfa9119c61a8676760c295c6cf39614913924, the library does not support remote images with uppercase extensions.

### Proposed solution
Enhance getImageSizeByExtension method. In the case of the library processing an image with an uppercase extensions (e.g. "test-image.PNG"), ensure that the library properly detects the correct type class.