### PR TITLE
Move strtolower() to method  handling the extension type

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -111,7 +111,7 @@ class FastImageSize
 		{
 			$extension = (isset($match[1])) ? $match[1] : preg_replace('/.+\/([a-z0-9-.]+)$/i', '$1', $type);
 
-			$this->getImageSizeByExtension($file, strtolower($extension));
+			$this->getImageSizeByExtension($file, $extension);
 		}
 
 		return sizeof($this->size) > 1 ? $this->size : false;


### PR DESCRIPTION
This removes the external dependency of supplying a lower-case string.