### PR TITLE
Require ext-mbstring for FastImageSize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3.0",
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Fixes hidden dependency issue described in #39