### PR TITLE
Supplied mime type should take priority over file extension

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -109,7 +109,7 @@ class FastImageSize
 		}
 		else
 		{
-			$extension = (isset($match[1])) ? $match[1] : preg_replace('/.+\/([a-z0-9-.]+)$/i', '$1', $type);
+			$extension = (empty($type) && isset($match[1])) ? $match[1] : preg_replace('/.+\/([a-z0-9-.]+)$/i', '$1', $type);
 
 			$this->getImageSizeByExtension($file, $extension);
 		}

--- a/tests/FastImageSize.php
+++ b/tests/FastImageSize.php
@@ -101,7 +101,7 @@ class FastImageSize extends \PHPUnit_Framework_TestCase
 			array('jpg.JPG', '', array('width' => 1, 'height' => 1, 'type' => IMAGETYPE_JPEG)),
 			array('png.PNG', 'image/png', array('width' => 1, 'height' => 1, 'type' => IMAGETYPE_PNG)),
 			array('png.PNG', '', array('width' => 1, 'height' => 1, 'type' => IMAGETYPE_PNG)),
-			array('jpg.JPG', 'image/png', array('width' => 1, 'height' => 1, 'type' => IMAGETYPE_JPEG)), // extension override incorrect mime type
+			array('jpg.JPG', 'image/png', false), // mime types override extension type
 			array('supercup.jpg', 'image/jpg', array('width' => 700, 'height' => 525, 'type' => IMAGETYPE_JPEG)),
 			array('641.jpg', 'image/jpg', array('width' => 641, 'height' => 399, 'type' => IMAGETYPE_JPEG)),
 		);


### PR DESCRIPTION
Supplying the mime type of a file will now correctly result in the mime
type taking priority over any file extension.

Fixes #43 