### PR TITLE
Fix return type annotation

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -79,7 +79,7 @@ class FastImageSize
 	 *
 	 * @param string $file Path to image that should be checked
 	 * @param string $type Mimetype of image
-	 * @return array|bool Array with image dimensions if successful, false if not
+	 * @return array|false Array with image dimensions if successful, false if not
 	 */
 	public function getImageSize($file, $type = '')
 	{


### PR DESCRIPTION
We are using this method and are checking for `!== false` but due to the wrong annotation, static analyse tools like PHPStan assume, that `true` is also returned, which is wrong