### PR TITLE
Fix #52 incorrect image extension

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -96,6 +96,12 @@ class FastImageSize
 			$extension = (empty($type) && isset($match[1])) ? $match[1] : preg_replace('/.+\/([a-z0-9-.]+)$/i', '$1', $type);
 
 			$this->getImageSizeByExtension($file, $extension);
+			
+			if(!(sizeof($this->size) > 1))
+			{
+				$this->data = '';
+				$this->getImagesizeUnknownType($file);
+			}
 		}
 
 		return sizeof($this->size) > 1 ? $this->size : false;


### PR DESCRIPTION
If we can't get sizes by extension treat like unknown image type.