### PR TITLE
Fix deprecation in file_get_contents call

### DIFF
--- a/lib/FastImageSize.php
+++ b/lib/FastImageSize.php
@@ -186,7 +186,7 @@ class FastImageSize
 	{
 		if (empty($this->data))
 		{
-			$this->data = @file_get_contents($filename, null, null, $offset, $length);
+			$this->data = @file_get_contents($filename, false, null, $offset, $length);
 		}
 
 		// Force length to expected one. Return false if data length


### PR DESCRIPTION
On PHP 8.1 this lib throws a deprecation warning, as it passes null as second param to `file_get_contents`, which should be a bool according to the method declaration.

Error message before this change:
```
file_get_contents(): Passing null to parameter #2 ($use_include_path) of type bool is deprecated
```